### PR TITLE
Fix logic for inserting slash after base URL

### DIFF
--- a/restclient.php
+++ b/restclient.php
@@ -160,7 +160,7 @@ class RestClient implements Iterator, ArrayAccess {
         }
         
         if($client->options['base_url']){
-            if($client->url[0] != '/' || substr($client->options['base_url'], -1) != '/')
+            if($client->url[0] != '/' && substr($client->options['base_url'], -1) != '/')
                 $client->url = '/' . $client->url;
             $client->url = $client->options['base_url'] . $client->url;
         }


### PR DESCRIPTION
Was adding slash if base url didn't end in / OR request path didn't
start with /. Changed to AND.
