### PR TITLE
fix: curl_exec may return false, and strtok will throw an error:

### DIFF
--- a/restclient.php
+++ b/restclient.php
@@ -212,7 +212,7 @@ class RestClient implements Iterator, ArrayAccess {
     public function parse_response($response) : void {
         $headers = [];
         $this->response_status_lines = [];
-        $line = strtok($response, "\n");
+        $line = strtok((string)$response, "\n");
         do {
             if(strlen(trim($line)) == 0){
                 // Since we tokenize on \n, use the remaining \r to detect empty lines.


### PR DESCRIPTION
TypeError: strtok() expects parameter 1 to be string, bool given