### PR TITLE
Clean strtok buffer from memory

### DIFF
--- a/restclient.php
+++ b/restclient.php
@@ -208,6 +208,7 @@ class RestClient implements Iterator, ArrayAccess {
         $client->error = curl_error($client->handle);
         
         curl_close($client->handle);
+        
         return $client;
     }
     
@@ -241,6 +242,7 @@ class RestClient implements Iterator, ArrayAccess {
         
         $this->headers = (object) $headers;
         $this->response = strtok("");
+        strtok("", ""); // Clean strtok buffer from memory
     }
     
     public function get_response_format() : string {


### PR DESCRIPTION
https://www.php.net/manual/en/function.strtok.php#103051 `strtok` function holds input string parameter (or reference to it?) in memory after usage.