### PR TITLE
Fixed PHP 8.2 deprecation

### DIFF
--- a/restclient.php
+++ b/restclient.php
@@ -12,6 +12,7 @@ class RestClient implements Iterator, ArrayAccess {
     
     public $options;
     public $handle; // cURL resource handle.
+    public $url;
     
     // Populated after execution:
     public $response; // Response body.


### PR DESCRIPTION
Fixed missing $url dynamic property which is depracated in PHP 8.2
