### PR TITLE
$fix Uninitialized string offset: 0 for $client->url

### DIFF
--- a/restclient.php
+++ b/restclient.php
@@ -186,12 +186,15 @@ class RestClient implements Iterator, ArrayAccess {
             $client->url .= strpos($client->url, '?')? '&' : '?';
             $client->url .= $parameters_string;
         }
-        
-        if($client->options['base_url']){
-            if($client->url[0] !== '/' && substr($client->options['base_url'], -1) !== '/')
-                $client->url = '/' . $client->url;
-            $client->url = $client->options['base_url'] . $client->url;
-        }
+
+		if ($client->options['base_url']) {
+			if (isset($client->url) && strlen($client->url) > 0) {
+				if ($client->url[0] !== '/' && substr($client->options['base_url'], -1) !== '/') {
+					$client->url = '/' . $client->url;
+				}
+			}
+			$client->url = $client->options['base_url'] . $client->url;
+		}
         $curlopt[CURLOPT_URL] = $client->url;
         
         if($client->options['curl_options']){


### PR DESCRIPTION
Encountered this NOTICE error on a project. 
The init was made with:
new RestClient([
	'base_url' => $some_url ?? '',
	'headers'  => ['API-KEY' => $some_api_key],
])

And the NOTICE looks like this:
{"code":8,"message":"Uninitialized string offset: 0","file":"/../../vendor/tcdent/php-restclient/restclient.php","line":190}